### PR TITLE
Correct link to Application Note

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In order to execute ELTT2, you need to compile it first:
 
 Due to hardware (and thus TPM) access restrictions for normal users, ELTT2 requires root (aka superuser or administrator) privileges. They can be obtained e.g. by using the 'sudo' command on Debian Linux derivates.
 
-The Infineon [TPM 2.0 Application Note](https://www.infineon.com/dgdl/Infineon-TPM20_SLB6970-AN-v01_00-EN.zip?fileId=5546d4625acbae4c015ad6d953664083) shows how the TPM device driver can be set up (e.g. for Linux Kernel 4.4).
+The Infineon [TPM 2.0 Application Note](https://www.infineon.com/dgdl/Infineon-TPM20_Embedded_SLB_9670_AppNote-AN-v01_00-EN.pdf?fileId=5546d46265257de8016537f329595e5c) shows how the TPM device driver can be set up (e.g. for Linux Kernel 4.4).
 
 
 


### PR DESCRIPTION
Fixes #12. Even though the filename extension in the URL is `.pdf`, a `.zip` file will be downloaded (similar to the previous link). Please check if the downloaded file is in fact the right one.