### PR TITLE
Use Markdown to emphasize commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ELTT2 - Infineon Embedded Linux TPM Toolbox 2 for TPM 2.0
  
 
-All information in this document is Copyright (c) 2014-2017, Infineon Technologies AG <br>
+All information in this document is Copyright (c) 2014-2022, Infineon Technologies AG <br>
 All rights reserved.
 
 
@@ -44,16 +44,16 @@ The Infineon [TPM 2.0 Application Note](https://www.infineon.com/dgdl/Infineon-A
 
 ELTT2 is operated as follows:
 
-Call: ./eltt2 \<option(s)\>
+Call: `./eltt2 <option(s)>`
 
-For example: ./eltt2 -g or ./eltt2 -gc
+For example: `./eltt2 -g` or `./eltt2 -gc`
 
-For getting an overview of the possible commands, run ./eltt2 -h
+For getting an overview of the possible commands, run `./eltt2 -h`
 
 Some options require the TPM to be in a specific state. This state is shown in brackets ("[]") behind each command line option in the list below:
 
 \[-\]: none <br>
-\[*\]: the TPM platform hierarchy authorization value is not set (i.e., empty buffer) <br>
+\[\*\]: the TPM platform hierarchy authorization value is not set (i.e., empty buffer) <br>
 \[l\]: the required PCR bank is allocated <br>
 \[u\]: started <br>
 
@@ -61,134 +61,134 @@ To get the TPM into the required state, call ELTT2 with the corresponding comman
 
  Command line option                                 | Explanation                                       | Precondition
  ---                                                 | ---                                               | ---
- -a \[hash algorithm\] \<data bytes\>                | Hash Sequence SHA-1/256/384 \[default: SHA-1\]    | \[u\]
- -A \<data bytes\>                                   | Hash Sequence SHA-256                             | \[u\]
- -b \<command bytes\>                                | Enter your own TPM command                        | \[u\]
- -c                                                  | Read Clock                                        | \[u\]
- -d \<shutdown type\>                                | Shutdown                                          | \[u\]
- -e \[hash algorithm\] \<PCR index\> \<PCR digest\>  | PCR Extend SHA-1/256/384 \[default: SHA-1\]       | \[u\], \[l\]
- -E \<PCR index\> \<PCR digest\>                     | PCR Extend SHA-256                                | \[u\], \[l\]
- -g                                                  | Get fixed capability values                       | \[u\]
- -v                                                  | Get variable capability values                    | \[u\]
- -G \<data length\>                                  | Get Random                                        | \[u\]
- -h                                                  | Help                                              | \[-\]
- -l \<hash algorithm\>                               | PCR Allocate SHA-1/256/384                        | \[u\], \[*\]
- -r \[hash algorithm\] \<PCR index\>                 | PCR Read SHA-1/256/384 \[default: SHA-1\]         | \[u\], \[l\]
- -R \<PCR index\>                                    | PCR Read SHA-256                                  | \[u\], \[l\]
- -s \[hash algorithm\] \<data bytes\>                | Hash SHA-1/256/384 \[default: SHA-1\]             | \[u\]
- -S \<data bytes\>                                   | Hash SHA-256                                      | \[u\]
- -t \<test type\>                                    | Self Test                                         | \[u\]
- -T                                                  | Get Test Result                                   | \[u\]
- -u \<startup type\>                                 | Startup                                           | \[-\]
- -z \<PCR index\>                                    | PCR Reset                                         | \[u\]
+ `-a [hash algorithm] <data bytes>`                  | Hash Sequence SHA-1/256/384 \[default: SHA-1\]    | \[u\]
+ `-A <data bytes>`                                   | Hash Sequence SHA-256                             | \[u\]
+ `-b <command bytes>`                                | Enter your own TPM command                        | \[u\]
+ `-c`                                                | Read Clock                                        | \[u\]
+ `-d <shutdown type>`                                | Shutdown                                          | \[u\]
+ `-e [hash algorithm] <PCR index> <PCR digest>`      | PCR Extend SHA-1/256/384 \[default: SHA-1\]       | \[u\], \[l\]
+ `-E <PCR index> <PCR digest>`                       | PCR Extend SHA-256                                | \[u\], \[l\]
+ `-g`                                                | Get fixed capability values                       | \[u\]
+ `-v`                                                | Get variable capability values                    | \[u\]
+ `-G <data length>`                                  | Get Random                                        | \[u\]
+ `-h`                                                | Help                                              | \[-\]
+ `-l <hash algorithm>`                               | PCR Allocate SHA-1/256/384                        | \[u\], \[\*\]
+ `-r [hash algorithm] <PCR index>`                   | PCR Read SHA-1/256/384 \[default: SHA-1\]         | \[u\], \[l\]
+ `-R <PCR index>`                                    | PCR Read SHA-256                                  | \[u\], \[l\]
+ `-s [hash algorithm] <data bytes>`                  | Hash SHA-1/256/384 \[default: SHA-1\]             | \[u\]
+ `-S <data bytes>`                                   | Hash SHA-256                                      | \[u\]
+ `-t <test type>`                                    | Self Test                                         | \[u\]
+ `-T`                                                | Get Test Result                                   | \[u\]
+ `-u <startup type>`                                 | Startup                                           | \[-\]
+ `-z <PCR index>`                                    | PCR Reset                                         | \[u\]
 
 
  Additional information:
 
--a: <br>
+`-a`: <br>
 With the "-a" command you can hash given data with the SHA-1/256/384 hash algorithm. This hash sequence sends 3 commands [start, update, complete] to the TPM and allows to hash an arbitrary amount of data. For example, use the following command to hash the byte sequence {0x41, 0x62, 0x43, 0x64}: <br>
-./eltt2 -a 41624364 Hash given data with SHA-1 hash algorithm. <br>
+`./eltt2 -a 41624364` Hash given data with SHA-1 hash algorithm. <br>
 or <br>
-./eltt2 -a sha1 41624364 Hash given data with SHA-1 hash algorithm. <br>
-./eltt2 -a sha256 41624364 Hash given data with SHA-256 hash algorithm. <br>
-./eltt2 -a sha384 41624364 Hash given data with SHA-384 hash algorithm. <br>
+`./eltt2 -a sha1 41624364` Hash given data with SHA-1 hash algorithm. <br>
+`./eltt2 -a sha256 41624364` Hash given data with SHA-256 hash algorithm. <br>
+`./eltt2 -a sha384 41624364` Hash given data with SHA-384 hash algorithm. <br>
 
--A: <br>
+`-A`: <br>
 With the "-A" command you can hash given data with the SHA-256 hash algorithm. This hash sequence sends 3 commands [start, update, complete] to the TPM and allows to hash an arbitrary amount of data. For example, use the following command to hash the byte sequence {0x41, 0x62, 0x43, 0x64}: <br>
-./eltt2 -A 41624364
+`./eltt2 -A 41624364`
 
--b: <br>
+`-b`: <br>
 With the "-b" command you can enter your own TPM command bytes and read the TPM response. For example, use the following command to send a TPM2_Startup with startup type CLEAR to the TPM: <br>
- ./eltt2 -b 80010000000C000001440000
+ `./eltt2 -b 80010000000C000001440000`
 
--c: <br>
+`-c`: <br>
 With the "-c" command you can read the clock values of the TPM. 
 
--d: <br>
+`-d`: <br>
 With the "-d" command you can issue a TPM shutdown. It has 2 options: <br>
-./eltt2 -d <br>
+`./eltt2 -d` <br>
 or <br>
-./eltt2 -d clear    send a TPM2_Shutdown command with shutdown type CLEAR to the TPM. <br>
-./eltt2 -d state    send a TPM2_Shutdown command with shutdown type STATE to the TPM. <br>
+`./eltt2 -d clear`    send a TPM2_Shutdown command with shutdown type CLEAR to the TPM. <br>
+`./eltt2 -d state`    send a TPM2_Shutdown command with shutdown type STATE to the TPM. <br>
 
- -e: <br>
+ `-e`: <br>
  With the "-e" command you can extend bytes in the selected PCR with SHA-1/256/384. To do so, you have to enter the index of PCR in hexadecimal that you like to extend and the digest you want to extend the selected PCR with. Note that you can only extend PCRs with index 0 to 16 and PCR 23 and that the digest must have a length of 20/32/48 bytes (will be padded with 0 if necessary). The TPM then builds an SHA-1/256/384 hash over the PCR data in the selected PCR and the digest you provided and writes the result back to the selected PCR. For example, use the following command to extend PCR 23 (0x17) with the byte sequence {0x41, 0x62, 0x43, 0x64, 0x00, ... (will be filled with 0x00)}: <br>
-./eltt2 -e 17 41624364 Extend bytes in PCR 23 with SHA-1. <br>
+`./eltt2 -e 17 41624364` Extend bytes in PCR 23 with SHA-1. <br>
 or <br>
-./eltt2 -e sha1 17 41624364 Extend bytes in PCR 23 with SHA-1. <br>
-./eltt2 -e sha256 17 41624364 Extend bytes in PCR 23 with SHA-256. <br>
-./eltt2 -e sha384 17 41624364 Extend bytes in PCR 23 with SHA-384. <br>
+`./eltt2 -e sha1 17 41624364` Extend bytes in PCR 23 with SHA-1. <br>
+`./eltt2 -e sha256 17 41624364` Extend bytes in PCR 23 with SHA-256. <br>
+`./eltt2 -e sha384 17 41624364` Extend bytes in PCR 23 with SHA-384. <br>
 
--E: <br>
+`-E`: <br>
 With the "-E" command you can extend bytes in the selected PCR with SHA-256. To do so, you have to enter the index of PCR in hexadecimal that you like to extend and the digest you want to extend the selected PCR with. Note that you can only extend PCRs with index 0 to 16 and PCR 23 and that the digest must have a length of 32 bytes (will be padded with 0 if necessary). The TPM then builds an SHA-256 hash over the PCR data in the selected PCR and the digest you provided and writes the result back to the selected PCR. For example, use the following command to extend PCR 23 (0x17) with the byte sequence {0x41, 0x62, 0x43, 0x64, 0x00, ... (will be filled with 0x00)}: <br>
- ./eltt2 -E 17 41624364
+ `./eltt2 -E 17 41624364`
 
--g: <br>
+`-g`: <br>
 With the "-g" command you can read the TPM's fixed properties.
 
--v: <br>
+`-v`: <br>
 With the "-v" command you can read the TPM's variable properties.
 
--G: <br>
+`-G`: <br>
 With the "-G" command you can get a given amount of random bytes. Note that you can only request a maximum amount of 32 random bytes at once. For example, use the following command to get 20 (0x14) random bytes: <br>
- ./eltt2 -G 14
+ `./eltt2 -G 14`
 
--l: <br>
+`-l`: <br>
 With the "-l" command you can allocate the SHA-1/256/384 PCR bank. Take note of two things. Firstly, the command requires a platform authorization value and it is set to an empty buffer; hence the command cannot be used if the TPM platform authorization value is set (e.g., by UEFI). Secondly, when the command is executed successfully a TPM reset has to follow for it to take effect. For example, use the following command to allocate a PCR bank: <br>
-./eltt2 -l sha1 Allocate SHA-1 PCR bank. <br>
-./eltt2 -l sha256 Allocate SHA-256 PCR bank. <br>
-./eltt2 -l sha384 Allocate SHA-384 PCR bank. <br>
+`./eltt2 -l sha1` Allocate SHA-1 PCR bank. <br>
+`./eltt2 -l sha256` Allocate SHA-256 PCR bank. <br>
+`./eltt2 -l sha384` Allocate SHA-384 PCR bank. <br>
 
--r: <br>
+`-r`: <br>
 With the "-r" command you can read data from a selected SHA-1/256/384 PCR. For example, use the following command to read data from PCR 23 (0x17): <br>
-./eltt2 -r 17 Read data from SHA-1 PCR 23. <br>
+`./eltt2 -r 17` Read data from SHA-1 PCR 23. <br>
 or <br>
-./eltt2 -r sha1 17 Read data from SHA-1 PCR 23. <br>
-./eltt2 -r sha256 17 Read data from SHA-256 PCR 23. <br>
-./eltt2 -r sha384 17 Read data from SHA-384 PCR 23. <br>
+`./eltt2 -r sha1 17` Read data from SHA-1 PCR 23. <br>
+`./eltt2 -r sha256 17` Read data from SHA-256 PCR 23. <br>
+`./eltt2 -r sha384 17` Read data from SHA-384 PCR 23. <br>
 
--R: <br>
+`-R`: <br>
 With the "-R" command you can read data from a selected SHA-256 PCR. For example, use the following command to read data from PCR 23 (0x17): <br>
- ./eltt2 -R 17
+ `./eltt2 -R 17`
 
--s: <br>
+`-s`: <br>
 With the "-s" command you can hash given data with the SHA-1/256/384 hash algorithm. This command only allows a limited amount of data to be hashed (depending on the TPM's maximum input buffer size). For example, use the following command to hash the byte sequence {0x41, 0x62, 0x43, 0x64}: <br>
-./eltt2 -s 41624364 Hash given data with SHA-1 hash algorithm. <br>
+`./eltt2 -s 41624364` Hash given data with SHA-1 hash algorithm. <br>
 or <br>
-./eltt2 -s sha1 41624364 Hash given data with SHA-1 hash algorithm. <br>
-./eltt2 -s sha256 41624364 Hash given data with SHA-256 hash algorithm. <br>
-./eltt2 -s sha384 41624364 Hash given data with SHA-384 hash algorithm. <br>
+`./eltt2 -s sha1 41624364` Hash given data with SHA-1 hash algorithm. <br>
+`./eltt2 -s sha256 41624364` Hash given data with SHA-256 hash algorithm. <br>
+`./eltt2 -s sha384 41624364` Hash given data with SHA-384 hash algorithm. <br>
 
--S: <br>
+`-S`: <br>
 With the "-S" command you can hash given data with the SHA-256 hash algorithm. This command only allows a limited amount of data to be hashed (depending on the TPM input buffer size). For example, use the following command to hash the byte sequence {0x41, 0x62, 0x43, 0x64}: <br>
- ./eltt2 -S 41624364
+ `./eltt2 -S 41624364`
 
--t: <br>
+`-t`: <br>
 With the "-t" command you can issue a TPM selftest. It has 3 options: <br>
-./eltt2 -t <br>
-or
-./eltt2 -t not_full Perform a partial TPM2_Selftest to test previously untested TPM capabilities. <br>
-./eltt2 -t full Perform a full TPM2_Selftest to test all TPM capabilities. <br>
-./eltt2 -t incremental  Perform a test of selected algorithms. 
+`./eltt2 -t` <br>
+or<br>
+`./eltt2 -t not_full` Perform a partial TPM2_Selftest to test previously untested TPM capabilities. <br>
+`./eltt2 -t full` Perform a full TPM2_Selftest to test all TPM capabilities. <br>
+`./eltt2 -t incremental`  Perform a test of selected algorithms. 
 
--T: <br>
+`-T`: <br>
 With the "-T" command you can read the results of a previously run selftest.
 
--u: <br>
+`-u`: <br>
 With the "-u" command you can issue a TPM startup command. It has 2 options: <br>
-./eltt2 -u <br>
+`./eltt2 -u` <br>
 or <br>
-./eltt2 -u clear send a TPM2_Startup with startup type CLEAR to the TPM. <br>
-./eltt2 -u state send a TPM2_Startup with startup type STATE to the TPM.
+`./eltt2 -u clear` send a TPM2_Startup with startup type CLEAR to the TPM. <br>
+`./eltt2 -u state` send a TPM2_Startup with startup type STATE to the TPM.
 
--z: <br>
+`-z`: <br>
 With the "-z" command you can reset a selected PCR. Note that you can only reset PCRs 16 and 23. For example, use the following command to reset PCR 23 (0x17): <br>
- ./eltt2 -z 17
+ `./eltt2 -z 17`
 
 ## 2.2 Examples:
 
 In order to work with the TPM, perform the following steps:
-- Send the TPM2_Startup command: ./eltt2 -u
+- Send the TPM2_Startup command: `./eltt2 -u`
 
 
 # 3. If you have questions
@@ -217,7 +217,7 @@ The ELTT2 response is "Error opening the device.":
 
 The ELTT2 responds with error code 0x100.
 - You need to send the TPM2_Startup command, or you did send it twice. In
-  case you have not sent it yet, do so with "./eltt2 -u".
+  case you have not sent it yet, do so with `./eltt2 -u`.
 
 The TPM does not change any of the permanent flags shown by sending the "-g"
 command , e.g. after a force clear.
@@ -227,4 +227,4 @@ command , e.g. after a force clear.
 The value of a PCR does not change after sending PCR extend or reset.
 - With the application permissions you cannot modify every PCR. For more
   details, please refer to the description for the different PCR commands
-in this file.
+  in this file.


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---


In order to improve readability, we can use the \`code\`   tag of markdown to highlight commands.
So eltt -h becomes `eltt-h`.

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>