### PR TITLE
cppcheck: Fix Shifting signed 32-bit value by 31 bits is implementation-defined behaviour

### DIFF
--- a/eltt2.c
+++ b/eltt2.c
@@ -951,7 +951,7 @@ static int print_capability_flags(uint8_t *response_buf, uint8_t cap_selector)
 						tmp = ((propertyValue & (1<<2)) == 0? 0:1); // Check bit 2 value.
 						printf("Eh Enable:                      %i %s", (tmp), ((tmp)? "SET\n" : "CLEAR\n"));
 						//bit 30:3 = reserved
-						tmp = ((propertyValue & (1<<31)) == 0? 0:1); // Check bit 31 value.
+						tmp = ((propertyValue & (1U<<31)) == 0? 0:1); // Check bit 31 value.
 						printf("Orderly:                        %i %s", (tmp), ((tmp)? "SET\n" : "CLEAR\n"));
 						break;
 					default:


### PR DESCRIPTION
cppcheck emits a warning:
`Shifting signed 32-bit value by 31 bits is implementation-defined behaviour`, which is correct.

=> Add U suffix to constant to fix the issue

Signed-off-by: Peter Huewe <Peter.Huewe@infineon.com>

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---