### PR TITLE
Add support for long commandline options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ELTT2 - Infineon Embedded Linux TPM Toolbox 2 for TPM 2.0
- 
+
 
 All information in this document is Copyright (c) 2014-2022, Infineon Technologies AG <br>
 All rights reserved.
@@ -61,29 +61,30 @@ To get the TPM into the required state, call ELTT2 with the corresponding comman
 
  Command line option                                 | Explanation                                       | Precondition
  ---                                                 | ---                                               | ---
- `-a [hash algorithm] <data bytes>`                  | Hash Sequence SHA-1/256/384 \[default: SHA-1\]    | \[u\]
- `-A <data bytes>`                                   | Hash Sequence SHA-256                             | \[u\]
- `-b <command bytes>`                                | Enter your own TPM command                        | \[u\]
- `-c`                                                | Read Clock                                        | \[u\]
- `-d <shutdown type>`                                | Shutdown                                          | \[u\]
- `-e [hash algorithm] <PCR index> <PCR digest>`      | PCR Extend SHA-1/256/384 \[default: SHA-1\]       | \[u\], \[l\]
- `-E <PCR index> <PCR digest>`                       | PCR Extend SHA-256                                | \[u\], \[l\]
- `-g`                                                | Get fixed capability values                       | \[u\]
- `-v`                                                | Get variable capability values                    | \[u\]
- `-G <data length>`                                  | Get Random                                        | \[u\]
- `-h`                                                | Help                                              | \[-\]
- `-l <hash algorithm>`                               | PCR Allocate SHA-1/256/384                        | \[u\], \[\*\]
- `-r [hash algorithm] <PCR index>`                   | PCR Read SHA-1/256/384 \[default: SHA-1\]         | \[u\], \[l\]
- `-R <PCR index>`                                    | PCR Read SHA-256                                  | \[u\], \[l\]
- `-s [hash algorithm] <data bytes>`                  | Hash SHA-1/256/384 \[default: SHA-1\]             | \[u\]
- `-S <data bytes>`                                   | Hash SHA-256                                      | \[u\]
- `-t <test type>`                                    | Self Test                                         | \[u\]
- `-T`                                                | Get Test Result                                   | \[u\]
- `-u <startup type>`                                 | Startup                                           | \[-\]
- `-z <PCR index>`                                    | PCR Reset                                         | \[u\]
+ `-a, --hashsequence-start [hash algorithm] <data bytes>`                  | Hash Sequence SHA-1/256/384 \[default: SHA-1\]    | \[u\]
+ `-A, --hashsequence-start-sha256 <data bytes>`                                   | Hash Sequence SHA-256                             | \[u\]
+ `-b, --enter-own-command <command bytes>`                                | Enter your own TPM command                        | \[u\]
+ `-c, --read-clock`                                                | Read Clock                                        | \[u\]
+ `-d, --shutdown <shutdown type>`                                | Shutdown                                          | \[u\]
+ `-e, --pcr-extend [hash algorithm] <PCR index> <PCR digest>`      | PCR Extend SHA-1/256/384 \[default: SHA-1\]       | \[u\], \[l\]
+ `-E, --pcr-extend-sha256 <PCR index> <PCR digest>`                       | PCR Extend SHA-256                                | \[u\], \[l\]
+ `-g, --getcap-fixed`                                                | Get fixed capability values                       | \[u\]
+ `-v, --getcap-var`                                                | Get variable capability values                    | \[u\]
+ `-G, --get-random <data length>`                                  | Get Random                                        | \[u\]
+ `-h, --help`                                                | Help                                              | \[-\]
+ `-l, --pcr-allocate <hash algorithm>`                               | PCR Allocate SHA-1/256/384                        | \[u\], \[\*\]
+ `-r, --pcr-read [hash algorithm] <PCR index>`                   | PCR Read SHA-1/256/384 \[default: SHA-1\]         | \[u\], \[l\]
+ `-R, --pcr-read-sha256 <PCR index>`                                    | PCR Read SHA-256                                  | \[u\], \[l\]
+ `-s, --hash [hash algorithm] <data bytes>`                  | Hash SHA-1/256/384 \[default: SHA-1\]             | \[u\]
+ `-S, --hash-sha256 <data bytes>`                                   | Hash SHA-256                                      | \[u\]
+ `-t, --seltftest <test type>`                                    | Self Test                                         | \[u\]
+ `-T, --get-testresult`                                                | Get Test Result                                   | \[u\]
+ `-u, --startup <startup type>`                                 | Startup                                           | \[-\]
+ `-z, --pcr-reset <PCR index>`                                    | PCR Reset                                         | \[u\]
 
 
- Additional information:
+ Additional information: <br>
+In this section, only short command line parameters are shown. But long ones can equally be used, e.g. `./eltt2 --hashsequence-start=sha256 41624364` can be used for `./eltt2 -a sha256 41624364`.
 
 `-a`: <br>
 With the "-a" command you can hash given data with the SHA-1/256/384 hash algorithm. This hash sequence sends 3 commands \[start, update, complete\] to the TPM and allows to hash an arbitrary amount of data. For example, use the following command to hash the byte sequence {0x41, 0x62, 0x43, 0x64}: <br>
@@ -102,7 +103,7 @@ With the "-b" command you can enter your own TPM command bytes and read the TPM 
  `./eltt2 -b 80010000000C000001440000`
 
 `-c`: <br>
-With the "-c" command you can read the clock values of the TPM. 
+With the "-c" command you can read the clock values of the TPM.
 
 `-d`: <br>
 With the "-d" command you can issue a TPM shutdown. It has 2 options: <br>
@@ -169,7 +170,7 @@ With the "-t" command you can issue a TPM selftest. It has 3 options: <br>
 or<br>
 `./eltt2 -t not_full` Perform a partial TPM2_Selftest to test previously untested TPM capabilities. <br>
 `./eltt2 -t full` Perform a full TPM2_Selftest to test all TPM capabilities. <br>
-`./eltt2 -t incremental`  Perform a test of selected algorithms. 
+`./eltt2 -t incremental`  Perform a test of selected algorithms.
 
 `-T`: <br>
 With the "-T" command you can read the results of a previously run selftest.

--- a/README.txt
+++ b/README.txt
@@ -98,7 +98,7 @@ Contents:
     Some options require the TPM to be in a specific state. This state is shown
     in brackets ("[]") behind each command line option in the list below:
 
-    [-]: none 
+    [-]: none
     [*]: the TPM platform hierarchy authorization value is not set (i.e., empty buffer)
     [l]: the required PCR bank is allocated
     [u]: started
@@ -111,49 +111,49 @@ Contents:
 
     Command line options:                                                                          Preconditions:
 
-    -a [hash algorithm] <data bytes>: Hash Sequence SHA-1/256/384 [default: SHA-1]                 [u]
+    -a, --hashsequence-start [hash algorithm] <data bytes>: Hash Sequence SHA-1/256/384 [default: SHA-1]                 [u]
 
-    -A <data bytes>: Hash Sequence SHA-256                                                         [u]
+    -A, --hashsequence-start-sha256 <data bytes>: Hash Sequence SHA-256                                                         [u]
 
-    -b <command bytes>: Enter your own TPM command                                                 [u]
+    -b, --enter-own-command <command bytes>: Enter your own TPM command                                                 [u]
 
-    -c: Read Clock                                                                                 [u]
+    -c, --read-clock: Read Clock                                                                                 [u]
 
-    -d <shutdown type>: Shutdown                                                                   [u]
+    -d, --shutdown <shutdown type>: Shutdown                                                                   [u]
 
-    -e [hash algorithm] <PCR index> <PCR digest>: PCR Extend SHA-1/256/384 [default: SHA-1]        [u], [l]
+    -e, --pcr-extend [hash algorithm] <PCR index> <PCR digest>: PCR Extend SHA-1/256/384 [default: SHA-1]        [u], [l]
 
-    -E <PCR index> <PCR digest>: PCR Extend SHA-256                                                [u], [l]
+    -E, --pcr-extend-sha256 <PCR index> <PCR digest>: PCR Extend SHA-256                                                [u], [l]
 
-    -g: Get fixed capability values                                                                [u]
+    -g, --getcap-fixed: Get fixed capability values                                                                [u]
 
-    -v: Get variable capability values                                                             [u]
+    -v, --getcap-var: Get variable capability values                                                             [u]
 
-    -G <data length>: Get Random                                                                   [u]
+    -G, --get-random <data length>: Get Random                                                                   [u]
 
-    -h: Help                                                                                       [-]
+    -h, --help: Help                                                                                       [-]
 
-    -l <hash algorithm>: PCR Allocate SHA-1/256/384                                                [u], [*]
+    -l, --pcr-allocate <hash algorithm>: PCR Allocate SHA-1/256/384                                                [u], [*]
 
-    -r [hash algorithm] <PCR index>: PCR Read SHA-1/256/384 [default: SHA-1]                       [u], [l]
+    -r, --pcr-read [hash algorithm] <PCR index>: PCR Read SHA-1/256/384 [default: SHA-1]                       [u], [l]
 
-    -R <PCR index>: PCR Read SHA-256                                                               [u], [l]
+    -R, --pcr-read-sha256 <PCR index>: PCR Read SHA-256                                                               [u], [l]
 
-    -s [hash algorithm] <data bytes>: Hash SHA-1/SHA256 [default: SHA-1]                           [u]
+    -s, --hash [hash algorithm] <data bytes>: Hash SHA-1/SHA256 [default: SHA-1]                           [u]
 
-    -S <data bytes>: Hash SHA-256                                                                  [u]
+    -S, --hash-sha256 <data bytes>: Hash SHA-256                                                                  [u]
 
-    -t <test type>: Self Test                                                                      [u]
+    -t, --seltftest <test type>: Self Test                                                                      [u]
 
-    -T: Get Test Result                                                                            [u]
+    -T, --get-testresult: Get Test Result                                                                            [u]
 
-    -u <startup type>: Startup                                                                     [-]
+    -u, --startup <startup type>: Startup                                                                     [-]
 
-    -z <PCR index>: PCR Reset                                                                      [u]
+    -z, --pcr-reset <PCR index>: PCR Reset                                                                      [u]
 
 
     Additional information:
-
+    In this section, only short command line parameters are shown. But long ones can equally be used, e.g. "./eltt2 --hashsequence-start=sha256 41624364" can be used for "./eltt2 -a sha256 41624364".
     -a:
     With the "-a" command you can hash given data with the SHA-1/256/384 hash
     algorithm. This hash sequence sends 3 commands [start, update, complete]

--- a/eltt2.c
+++ b/eltt2.c
@@ -59,6 +59,33 @@ int main(int argc, char **argv)
 	int no_transmission = 0;		// Flag to skip the transmission call, e.g. in case of command line option -h.
 	int tpm_error = 0;			// Flag to indicate whether a TPM response has returned a TPM error code or not.
 	hash_algo_enum hash_algo = ALG_NULL;	// Variable to indicate the selected hash algorithm.
+	int option_index = -1; // Variable to indicate the option index stored by getopt_long
+
+	// Define possible command line options
+	static const struct option commandline_options[] =
+	{
+		{"hashsequence-start", required_argument, 0, 'a'},
+		{"hashsequence-start-sha256", required_argument, 0, 'A'},
+		{"enter-own-command", required_argument, 0, 'b'},
+		{"read-clock", no_argument, 0, 'c'},
+		{"shutdown", required_argument, 0, 'd'},
+		{"pcr-extend", required_argument, 0, 'e'},
+		{"pcr-extend-sha256", required_argument, 0, 'E'},
+		{"getcap-fixed", no_argument, 0, 'g'},
+		{"getcap-var", no_argument, 0, 'v'},
+		{"get-random", required_argument, 0, 'G'},
+		{"help", no_argument, 0, 'h'},
+		{"pcr-allocate", required_argument, 0, 'l'},
+		{"pcr-read", required_argument, 0, 'r'},
+		{"pcr-read-sha256", required_argument, 0, 'R'},
+		{"hash", required_argument, 0, 's'},
+		{"hash-sha256", required_argument, 0, 'S'},
+		{"seltftest", required_argument, 0, 't'},
+		{"get-testresult", no_argument, 0, 'T'},
+		{"startup", required_argument, 0, 'u'},
+		{"pcr-reset", required_argument, 0, 'z'},
+		{0, 0, 0, 0}
+	};
 
 	// ---------- Program flow ----------
 	printf("\n");
@@ -81,8 +108,8 @@ int main(int argc, char **argv)
 		// ---------- Command line parsing with getopt ----------
 		opterr = 0; // Disable getopt error messages in case of unknown parameters; we want to use our own error messages.
 
-		// Loop through parameters with getopt.
-		while (-1 != (option = getopt(argc, argv, "cgvhTa:A:b:d:e:E:G:l:r:R:s:S:t:u:z:")))
+		// Loop through parameters with getopt_long.
+		while (-1 != (option = getopt_long(argc, argv, "cgvhTa:A:b:d:e:E:G:l:r:R:s:S:t:u:z:", commandline_options, &option_index)))
 		{
 			switch (option)
 			{
@@ -745,46 +772,46 @@ static int print_response_buf(uint8_t *response_buf, size_t resp_size, uint32_t 
 
 static void print_help()
 {
-	printf("'-a [hash algorithm] <data bytes>': Hash Sequence SHA-1/256/384 [default: SHA-1]\n");
+	printf("'-a, --hashsequence-start [hash algorithm] <data bytes>': Hash Sequence SHA-1/256/384 [default: SHA-1]\n");
 	printf("        -> Hash algorithm: Enter hash algorithm like 'sha1', 'sha256', 'sha384'\n");
 	printf("           Data bytes: Enter a byte sequence like '0F56...' for {0x0f, 0x56, ...}\n");
-	printf("'-A <data bytes>': Hash Sequence SHA-256\n");
+	printf("'-A, --hashsequence-start-sha256 <data bytes>': Hash Sequence SHA-256\n");
 	printf("        -> Data bytes: Enter a byte sequence like '0F56...' for {0x0f, 0x56, ...}\n");
-	printf("'-b <command bytes>': Enter your own TPM command\n");
+	printf("'-b, --enter-own-command <command bytes>': Enter your own TPM command\n");
 	printf("        -> Command bytes: Enter your command bytes in hex like '0f56...' for {0x0f, 0x56, ...}\n");
-	printf("'-c': Read Clock\n");
-	printf("'-d <shutdown type>': Shutdown\n");
+	printf("'-c, --read-clock': Read Clock\n");
+	printf("'-d, --shutdown <shutdown type>': Shutdown\n");
 	printf("        -> Shutdown types: clear [default], state\n");
-	printf("'-e [hash algorithm] <PCR index> <PCR digest>': PCR Extend SHA-1/256/384 [default: SHA-1]\n");
+	printf("'-e, --pcr-extend [hash algorithm] <PCR index> <PCR digest>': PCR Extend SHA-1/256/384 [default: SHA-1]\n");
 	printf("        -> Hash algorithm: Enter hash algorithm like 'sha1', 'sha256', 'sha384'\n");
 	printf("           PCR index:  Enter the PCR index in hex like '17' for 0x17\n");
 	printf("           PCR digest: Enter the value to extend the PCR with in hex like '0f56...' for {0x0f, 0x56, ...}\n");
-	printf("'-E <PCR index> <PCR digest>': PCR Extend SHA-256\n");
+	printf("'-E, --pcr-extend-sha256 <PCR index> <PCR digest>': PCR Extend SHA-256\n");
 	printf("        -> PCR index:  Enter the PCR index in hex like '17' for 0x17\n");
 	printf("           PCR digest: Enter the value to extend the PCR with in hex like '0f56...' for {0x0f, 0x56, ...}\n");
-	printf("'-g': Get fixed capability values\n");
-	printf("'-v': Get variable capability values\n");
-	printf("'-G <byte count>': Get Random\n");
+	printf("'-g, --getcap-fixed': Get fixed capability values\n");
+	printf("'-v, --getcap-var': Get variable capability values\n");
+	printf("'-G, --get-random <byte count>': Get Random\n");
 	printf("        -> Enter desired number of random bytes in hex like '20' for 0x20 (=32 bytes, maximum)\n");
-	printf("'-h': Help\n");
-	printf("'-l <hash algorithm>': PCR allocate SHA-1/256/384\n");
+	printf("'-h, --help': Help\n");
+	printf("'-l, --pcr-allocate <hash algorithm>': PCR allocate SHA-1/256/384\n");
 	printf("        -> Hash algorithm: Enter hash algorithm like 'sha1', 'sha256', 'sha384'\n");
-	printf("'-r [hash algorithm] <PCR index>': PCR Read SHA-1/256/384 [default: SHA-1]\n");
+	printf("'-r, --pcr-read [hash algorithm] <PCR index>': PCR Read SHA-1/256/384 [default: SHA-1]\n");
 	printf("        -> Hash algorithm: Enter hash algorithm like 'sha1', 'sha256', 'sha384'\n");
 	printf("           PCR index: Enter PCR number in hex like '17' for 0x17\n");
-	printf("'-R <PCR index>': PCR Read SHA-256\n");
+	printf("'-R, --pcr-read-sha256 <PCR index>': PCR Read SHA-256\n");
 	printf("        -> PCR index: Enter PCR number in hex like '17' for 0x17\n");
-	printf("'-s [hash algorithm] <data bytes>': Hash SHA-1/256/384 [default: SHA-1]\n");
+	printf("'-s, --hash [hash algorithm] <data bytes>': Hash SHA-1/256/384 [default: SHA-1]\n");
 	printf("        -> Hash algorithm: Enter hash algorithm like 'sha1', 'sha256', 'sha384'\n");
 	printf("           Data bytes: Enter a byte sequence like '0F56...' for {0x0f, 0x56, ...}\n");
-	printf("'-S <data bytes>': Hash SHA-256\n");
+	printf("'-S, --hash-sha256 <data bytes>': Hash SHA-256\n");
 	printf("        -> Data bytes: Enter a byte sequence like '0F56...' for {0x0f, 0x56, ...}\n");
-	printf("'-t <selftest type>': SelfTest\n");
+	printf("'-t, --seltftest <selftest type>': SelfTest\n");
 	printf("        -> Selftest type: not_full [default], full, incremental\n");
-	printf("'-T': Get Test Result\n");
-	printf("'-u <startup type>': Startup\n");
+	printf("'-T, --get-testresult': Get Test Result\n");
+	printf("'-u, --startup <startup type>': Startup\n");
 	printf("        -> Startup types: clear [default], state\n");
-	printf("'-z <PCR index>': PCR Reset SHA-1, SHA-256, and SHA-384\n");
+	printf("'-z, --pcr-reset <PCR index>': PCR Reset SHA-1, SHA-256, and SHA-384\n");
 	printf("        -> PCR index: Enter PCR number in hex like '17' for 0x17\n");
 }
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
Add support for long command line options, e.g. --help instead of only -h. 