### PR TITLE
Add output to pcr allocate to ask for TPM reset

### DIFF
--- a/eltt2.c
+++ b/eltt2.c
@@ -1615,23 +1615,25 @@ static int pcr_allocate(uint8_t *pcr_cmd_buf, hash_algo_enum hash_algo)
 			memcpy(pcr_cmd_buf + 34, set, sizeof(set));
 			memcpy(pcr_cmd_buf + 40, clear, sizeof(clear));
 			memcpy(pcr_cmd_buf + 46, clear, sizeof(clear));
-			printf("PCR allocate SHA-1 bank\n");
+			printf("PCR allocate SHA-1 bank.\n");
 		}
 		else if (ALG_SHA256 == hash_algo)
 		{
 			memcpy(pcr_cmd_buf + 34, clear, sizeof(clear));
 			memcpy(pcr_cmd_buf + 40, set, sizeof(set));
 			memcpy(pcr_cmd_buf + 46, clear, sizeof(clear));
-			printf("PCR allocate SHA-256 bank\n");
+			printf("PCR allocate SHA-256 bank.\n");
 		}
 		else if (ALG_SHA384 == hash_algo)
 		{
 			memcpy(pcr_cmd_buf + 34, clear, sizeof(clear));
 			memcpy(pcr_cmd_buf + 40, clear, sizeof(clear));
 			memcpy(pcr_cmd_buf + 46, set, sizeof(set));
-			printf("PCR allocate SHA-384 bank\n");
+			printf("PCR allocate SHA-384 bank.\n");
 		}
 	} while (0);
+
+	printf("In order to take effect, please perform a TPM reset.\n");
 
 	return ret_val;
 }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Add a comment to the output of pcr allocate to remember the user to perform a TPM reset.
e.g. output of `eltt2 -l sha1` looks now like that:
```
PCR allocate SHA-1 bank.
In order to take effect, please perform a TPM reset.
Done. 
```